### PR TITLE
[ADD] website_event_tournament

### DIFF
--- a/setup/website_event_tournament/odoo/addons/website_event_tournament
+++ b/setup/website_event_tournament/odoo/addons/website_event_tournament
@@ -1,0 +1,1 @@
+../../../../website_event_tournament

--- a/setup/website_event_tournament/setup.py
+++ b/setup/website_event_tournament/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/website_event_tournament/README.rst
+++ b/website_event_tournament/README.rst
@@ -1,0 +1,1 @@
+Show tournaments in website

--- a/website_event_tournament/__init__.py
+++ b/website_event_tournament/__init__.py
@@ -1,0 +1,1 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).

--- a/website_event_tournament/__init__.py
+++ b/website_event_tournament/__init__.py
@@ -1,1 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import controllers

--- a/website_event_tournament/__init__.py
+++ b/website_event_tournament/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import controllers
+from . import models

--- a/website_event_tournament/__manifest__.py
+++ b/website_event_tournament/__manifest__.py
@@ -15,5 +15,7 @@
     "data": [
         "security/ir.model.access.csv",
         "templates/event_registration_templates.xml",
+        "templates/event_templates.xml",
+        "views/event_tournament_view.xml",
     ],
 }

--- a/website_event_tournament/__manifest__.py
+++ b/website_event_tournament/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": "Manage tournaments in website",
     "version": "15.0.1.0.0",
     "category": "Website",
-    "author": "Simone Rubino, Odoo Community Association (OCA)",
+    "author": "Daemo00's developments",
     "website": "https://github.com/Daemo00/odoo-modules/tree/15.0/event_tournament",
     "license": "AGPL-3",
     "depends": [

--- a/website_event_tournament/__manifest__.py
+++ b/website_event_tournament/__manifest__.py
@@ -1,0 +1,18 @@
+#  Copyright 2022 Simone Rubino
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Tournaments in website",
+    "summary": "Manage tournaments in website",
+    "version": "15.0.1.0.0",
+    "category": "Website",
+    "author": "Simone Rubino, Odoo Community Association (OCA)",
+    "website": "https://github.com/Daemo00/odoo-modules/tree/15.0/event_tournament",
+    "license": "AGPL-3",
+    "depends": [
+        "website_event",
+        "event_tournament",
+    ],
+    "data": [
+        "templates/event_registration_templates.xml",
+    ],
+}

--- a/website_event_tournament/__manifest__.py
+++ b/website_event_tournament/__manifest__.py
@@ -6,7 +6,8 @@
     "version": "16.0.1.0.0",
     "category": "Website",
     "author": "Daemo00's developments",
-    "website": "https://github.com/Daemo00/odoo-modules",
+    "website": "https://github.com/Daemo00/odoo-modules"
+    "/tree/15.0/website_event_tournament",
     "license": "AGPL-3",
     "depends": [
         "website_event",

--- a/website_event_tournament/__manifest__.py
+++ b/website_event_tournament/__manifest__.py
@@ -3,10 +3,10 @@
 {
     "name": "Tournaments in website",
     "summary": "Manage tournaments in website",
-    "version": "15.0.1.0.0",
+    "version": "16.0.1.0.0",
     "category": "Website",
     "author": "Daemo00's developments",
-    "website": "https://github.com/Daemo00/odoo-modules/tree/15.0/event_tournament",
+    "website": "https://github.com/Daemo00/odoo-modules",
     "license": "AGPL-3",
     "depends": [
         "website_event",

--- a/website_event_tournament/__manifest__.py
+++ b/website_event_tournament/__manifest__.py
@@ -19,4 +19,9 @@
         "templates/event_templates.xml",
         "views/event_tournament_view.xml",
     ],
+    "assets": {
+        "web.assets_frontend": [
+            "website_event_tournament/static/src/js/registration.js",
+        ],
+    },
 }

--- a/website_event_tournament/__manifest__.py
+++ b/website_event_tournament/__manifest__.py
@@ -13,6 +13,7 @@
         "event_tournament",
     ],
     "data": [
+        "security/ir.model.access.csv",
         "templates/event_registration_templates.xml",
     ],
 }

--- a/website_event_tournament/controllers/__init__.py
+++ b/website_event_tournament/controllers/__init__.py
@@ -1,0 +1,3 @@
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import main

--- a/website_event_tournament/controllers/main.py
+++ b/website_event_tournament/controllers/main.py
@@ -1,0 +1,68 @@
+#  Copyright 2022 Simone Rubino
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import re
+
+from odoo.fields import first
+from odoo.http import request
+
+from odoo.addons.website_event.controllers.main import WebsiteEventController
+
+
+class WebsiteEventTournamentController(WebsiteEventController):
+    def get_team_names(self, value):
+        # Extract quoted teams
+        pattern = re.compile(r"\"([^\"]*)\"")
+        quoted_teams = pattern.findall(value)
+
+        # Extract unquoted teams
+        unquoted_teams_str = pattern.sub("", value)  # Remove quoted teams
+        unquoted_teams_list = unquoted_teams_str.split(",")
+        unquoted_teams_list = map(
+            str.strip, unquoted_teams_list
+        )  # Remove spaces from teams names
+        unquoted_teams_list = filter(None, unquoted_teams_list)  # Purge empty names
+        unquoted_teams_list = list(unquoted_teams_list)
+
+        teams_names = quoted_teams + unquoted_teams_list
+        return teams_names
+
+    def _process_attendees_form(self, event, form_details):
+        """
+        Process data posted from the attendee details form.
+
+        There will be fields formatted like team_names-#{counter}-#{tournament.id}.
+        """
+        registrations_values = super()._process_attendees_form(event, form_details)
+
+        tournament_model = request.env["event.tournament"]
+        for key, value in form_details.items():
+            if key.startswith("team_names"):
+                input_name, registration_index, tournament_id = key.split("-")
+                # Registration form is 1-based but list is 0-based
+                registration_index = int(registration_index) - 1
+                registration_values = registrations_values[registration_index]
+                tournament = tournament_model.browse(int(tournament_id))
+                registration_values.setdefault("tournament_ids", list()).append(
+                    (4, tournament.id)
+                )
+                if input_name == "team_names":
+                    tournament_teams = tournament.team_ids
+                    teams_names = self.get_team_names(value)
+                    for team_name in teams_names:
+                        tournament_team = tournament_teams.filtered_domain(
+                            [("name", "=", team_name)]
+                        )
+                        tournament_team = first(tournament_team)
+                        if not tournament_team:
+                            # Team does not exist, create it
+                            tournament_team = tournament_team.create(
+                                {
+                                    "tournament_id": tournament.id,
+                                    "name": team_name,
+                                }
+                            )
+                        registration_values.setdefault(
+                            "tournament_team_ids", list()
+                        ).append((4, tournament_team.id))
+
+        return registrations_values

--- a/website_event_tournament/controllers/main.py
+++ b/website_event_tournament/controllers/main.py
@@ -40,11 +40,9 @@ class WebsiteEventTournamentController(WebsiteEventController):
                 input_name, registration_index, tournament_id = key.split("-")
                 # Registration form is 1-based but list is 0-based
                 registration_index = int(registration_index) - 1
+
                 registration_values = registrations_values[registration_index]
                 tournament = tournament_model.browse(int(tournament_id))
-                registration_values.setdefault("tournament_ids", list()).append(
-                    (4, tournament.id)
-                )
                 if input_name == "team_names":
                     tournament_teams = tournament.team_ids
                     teams_names = self.get_team_names(value)

--- a/website_event_tournament/models/__init__.py
+++ b/website_event_tournament/models/__init__.py
@@ -1,3 +1,4 @@
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import event_registration
+from . import event_tournament

--- a/website_event_tournament/models/__init__.py
+++ b/website_event_tournament/models/__init__.py
@@ -1,0 +1,3 @@
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import event_registration

--- a/website_event_tournament/models/event_registration.py
+++ b/website_event_tournament/models/event_registration.py
@@ -1,0 +1,20 @@
+#  Copyright 2022 Simone Rubino
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class EventRegistration(models.Model):
+    _inherit = "event.registration"
+
+    def _get_website_registration_allowed_fields(self):
+        allowed_fields = super()._get_website_registration_allowed_fields()
+        allowed_fields.update(
+            {
+                "birthday_date",
+                "gender",
+                "mobile",
+                "is_fipav",
+            }
+        )
+        return allowed_fields

--- a/website_event_tournament/models/event_registration.py
+++ b/website_event_tournament/models/event_registration.py
@@ -11,7 +11,7 @@ class EventRegistration(models.Model):
         allowed_fields = super()._get_website_registration_allowed_fields()
         allowed_fields.update(
             {
-                "birthday_date",
+                "birthdate_date",
                 "gender",
                 "mobile",
                 "is_fipav",

--- a/website_event_tournament/models/event_tournament.py
+++ b/website_event_tournament/models/event_tournament.py
@@ -1,0 +1,15 @@
+#  Copyright 2022 Simone Rubino
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+from odoo.tools import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class EventTournament(models.Model):
+    _inherit = "event.tournament"
+
+    website_description = fields.Html(
+        translate=True,
+    )

--- a/website_event_tournament/security/ir.model.access.csv
+++ b/website_event_tournament/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+access_event_tournament,public_event_tournament,event_tournament.model_event_tournament,,1,0,0,0
+access_event_tournament_team,public_event_tournament_team,event_tournament.model_event_tournament_team,,1,1,1,0

--- a/website_event_tournament/static/src/js/registration.js
+++ b/website_event_tournament/static/src/js/registration.js
@@ -1,0 +1,13 @@
+odoo.define("website_event_tournament.attendee_details", function (require) {
+    "use strict";
+
+    $(document).ready(function () {
+        // Does not bind because modal does not exist when document is ready: when is it populated?
+        $("#attendee_registration button[name='js_copy_team']").on(
+            "click",
+            function (e) {
+                alert("hi");
+            }
+        );
+    });
+});

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -38,7 +38,7 @@
                         t-attf-name="#{counter}-gender"
                         required="required"
                     >
-                        <option selected="selected">Select...</option>
+                        <option value="" selected="selected">Select...</option>
                         <t t-foreach="gender_selection" t-as="value_string">
                             <option
                                 t-att-value="value_string[0]"

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -69,21 +69,13 @@
                     <strong t-esc="tournament.name" />
                 </div>
                 <div class="col">
-                    <label>Team names</label>
+                    <label>Team name</label>
                     <input
                         class="form-control"
                         type="text"
-                        t-attf-name="team_names-#{counter}-#{tournament.id}"
-                        t-attf-aria-describedby="help_team_names-#{counter}-#{tournament.id}"
-                        placeholder="Banana hammocks, &quot;You know, we are great&quot;, Pterodactyls"
+                        t-attf-name="team_name-#{counter}-#{tournament.id}"
+                        placeholder="Banana hammocks"
                     />
-                    <small
-                        t-attf-id="help_team_names-#{counter}-#{tournament.id}"
-                        class="form-text text-muted"
-                    >
-                        List team names with comma (',').
-                        If your team name has a comma in it, enter the team name between double quotes ('"').
-                    </small>
                 </div>
                 <!-- TODO Add button to copy team names in other attendees -->
             </div>

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -43,4 +43,35 @@
             </div>
         </xpath>
     </template>
+
+    <template
+        id="registration_complete"
+        inherit_id="website_event.registration_complete"
+        name="Add tournament details to attendee confirmation"
+    >
+        <xpath expr="//t[@t-if='attendee.email']/.." position="before">
+            <t t-set="tournaments" t-value="attendee.tournament_ids" />
+            <ul class="fa-ul" t-if="tournaments">
+                <li t-foreach="attendee.tournament_ids" t-as="tournament">
+                    <span class="fa-li">
+                        <i class="fa fa-trophy" />
+                    </span>
+                    <span t-esc="tournament.name" />
+
+                    <t
+                        t-set="tournament_teams"
+                        t-value="attendee.tournament_team_ids.filtered(lambda t: t.tournament_id == tournament)"
+                    />
+                    <ul class="fa-ul">
+                        <li t-foreach="tournament_teams" t-as="team">
+                            <span class="fa-li">
+                                <i class="fa fa-users" />
+                            </span>
+                            <span t-esc="team.name" />
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </xpath>
+    </template>
 </odoo>

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -26,7 +26,7 @@
                 <div class="col">
                     <t
                         t-set="gender_description"
-                        t-value="event.registration_ids._fields['gender'].get_description(env)"
+                        t-value="env['event.registration']._fields['gender'].get_description(env)"
                     />
                     <t
                         t-set="gender_selection"

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -65,7 +65,7 @@
                 class="row"
                 style="border: solid 2px red;"
             >
-                <div class="col-2 align-self-center">
+                <div class="col-2 align-self-center" style="text-align-last: end;">
                     <strong t-esc="tournament.name" />
                 </div>
                 <div class="col">
@@ -76,6 +76,16 @@
                         t-attf-name="team_name-#{counter}-#{tournament.id}"
                         placeholder="Banana hammocks"
                     />
+                </div>
+                <div class="align-self-center col-2" t-if="ticket['quantity'] > 1">
+                    <button
+                        type="button"
+                        class="btn btn-info"
+                        name="js_copy_team"
+                        t-attf-data-team-input="team_name-#{counter}-#{tournament.id}"
+                    >
+                        Copy to other participants
+                    </button>
                 </div>
                 <!-- TODO Add button to copy team names in other attendees -->
             </div>

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -13,6 +13,52 @@
             expr="//t[@name='attendee_loop']//*[hasclass('modal-body')]"
             position="inside"
         >
+            <div class="row" style="border: solid 2px red;">
+                <div class="col">
+                    <label>Birthday</label>
+                    <input
+                        class="form-control"
+                        type="date"
+                        t-attf-name="#{counter}-birthday_date"
+                        required="required"
+                    />
+                </div>
+                <div class="col">
+                    <t
+                        t-set="gender_description"
+                        t-value="event.registration_ids._fields['gender'].get_description(env)"
+                    />
+                    <t
+                        t-set="gender_selection"
+                        t-value="gender_description['selection']"
+                    />
+                    <label>Gender</label>
+                    <select
+                        class="form-control"
+                        t-attf-name="#{counter}-gender"
+                        required="required"
+                    >
+                        <option selected="selected">Select...</option>
+                        <t t-foreach="gender_selection" t-as="value_string">
+                            <option
+                                t-att-value="value_string[0]"
+                                t-esc="value_string[1]"
+                            />
+                        </t>
+                    </select>
+                </div>
+                <div class="col">
+                    <label t-attf-for="#{counter}-is_fipav">
+                        Is FIPAV
+                    </label>
+                    <input
+                        class="form-control"
+                        type="checkbox"
+                        t-attf-name="#{counter}-is_fipav"
+                        t-attf-id="#{counter}-is_fipav"
+                    />
+                </div>
+            </div>
             <div
                 t-foreach="event.tournament_ids"
                 t-as="tournament"

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -19,7 +19,7 @@
                     <input
                         class="form-control"
                         type="date"
-                        t-attf-name="#{counter}-birthday_date"
+                        t-attf-name="#{counter}-birthdate_date"
                         required="required"
                     />
                 </div>

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -13,7 +13,7 @@
             expr="//t[@name='attendee_loop']//*[hasclass('modal-body')]"
             position="inside"
         >
-            <div class="row" style="border: solid 2px red;">
+            <div class="row" style="border: solid 2px red;" t-if="event.tournament_ids">
                 <div class="col">
                     <label>Birthday</label>
                     <input

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2022 Simone Rubino
+  ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+  -->
+<odoo>
+    <template
+        id="registration_attendee_details"
+        inherit_id="website_event.registration_attendee_details"
+        name="Add tournament details to attendee registration"
+    >
+        <xpath
+            expr="//t[@name='attendee_loop']//*[hasclass('modal-body')]"
+            position="inside"
+        >
+            <div
+                t-foreach="event.tournament_ids"
+                t-as="tournament"
+                class="row"
+                style="border: solid 2px red;"
+            >
+                <div class="col-2 align-self-center">
+                    <strong t-esc="tournament.name" />
+                </div>
+                <div class="col">
+                    <label>Team names</label>
+                    <input
+                        class="form-control"
+                        type="text"
+                        t-attf-name="#{counter}-team_name"
+                        required="This field is required"
+                        t-attf-aria-describedby="#{counter}-team_name_help"
+                        placeholder="Banana hammocks, &quot;You know, we are great&quot;, Pterodactyls"
+                    />
+                    <small
+                        t-attf-id="#{counter}-team_name_help"
+                        class="form-text text-muted"
+                    >
+                        List team names with comma (',').
+                        If your team name has a comma in it, enter the team name between double quotes ('"').
+                    </small>
+                </div>
+                <!-- TODO Add button to copy team names in other attendees -->
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/website_event_tournament/templates/event_registration_templates.xml
+++ b/website_event_tournament/templates/event_registration_templates.xml
@@ -27,13 +27,12 @@
                     <input
                         class="form-control"
                         type="text"
-                        t-attf-name="#{counter}-team_name"
-                        required="This field is required"
-                        t-attf-aria-describedby="#{counter}-team_name_help"
+                        t-attf-name="team_names-#{counter}-#{tournament.id}"
+                        t-attf-aria-describedby="help_team_names-#{counter}-#{tournament.id}"
                         placeholder="Banana hammocks, &quot;You know, we are great&quot;, Pterodactyls"
                     />
                     <small
-                        t-attf-id="#{counter}-team_name_help"
+                        t-attf-id="help_team_names-#{counter}-#{tournament.id}"
                         class="form-text text-muted"
                     >
                         List team names with comma (',').

--- a/website_event_tournament/templates/event_templates.xml
+++ b/website_event_tournament/templates/event_templates.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2022 Simone Rubino
+  ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+  -->
+<odoo>
+    <template
+        id="event_description_full"
+        inherit_id="website_event.event_description_full"
+        name="Tournament details in event description"
+    >
+        <span t-field="event.description" position="after">
+            <t t-foreach="event.tournament_ids" t-as="tournament">
+                <span t-esc="tournament.website_description" />
+            </t>
+        </span>
+    </template>
+</odoo>

--- a/website_event_tournament/views/event_tournament_view.xml
+++ b/website_event_tournament/views/event_tournament_view.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright 2022 Simone Rubino
+  ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+  -->
+<odoo>
+    <record id="event_tournament_view_form" model="ir.ui.view">
+        <field name="name">Add website fields in event.tournament form view</field>
+        <field name="model">event.tournament</field>
+        <field name="inherit_id" ref="event_tournament.event_tournament_view_form" />
+        <field name="arch" type="xml">
+            <page name="notes" position="inside">
+                <group>
+                    <field name="website_description" />
+                </group>
+            </page>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Website integration
- Subscribe from website to team
- Registration is subscribed to tournament of its team automatically. Thanks to event.registration._compute_tournaments
- Show teams in registration confirmation
- Common registration fields in website, missing date parsing
- Show common registration fields only if there is a tournament
- Fix typo on birthdate_date
- Portal user can't access event registrations
- Enforce empty value for no gender selected
- Website description for tournament
- Fix team creation in website registration: teams must be created after components
- It actually only makes sense to attend to only 1 tam per tournament
- fix author due to updated pre-commit
- Fix website links due to updated pre-commit
- Entire website link
- WIP
